### PR TITLE
Add windows property to new infrastructure

### DIFF
--- a/initServiceDownloads.yml
+++ b/initServiceDownloads.yml
@@ -37,3 +37,4 @@
     - role: properties/qa
     - role: properties/shared
     - role: properties/talks
+    - role: properties/windows

--- a/inventory/php.net.zone
+++ b/inventory/php.net.zone
@@ -109,7 +109,8 @@ pres2			IN CNAME pres2-php-net.ax4z.com.
 ; wiki.internal is name of host, see Digital Ocean section
 wiki			IN CNAME wiki-php-net.ax4z.com.
 
-; windows.php.net is configured entirely as a physical host below
+; old windows.php.net website, which besides robots.txt now redirects to other locations (only)
+windows		IN CNAME windows-php-net.ax4z.com.
 
 ; www is kind of a big deal
 www                  300 IN CNAME www-php-net.ax4z.com.
@@ -170,12 +171,6 @@ php-jump2		IN AAAA 2a01:4f8:c2c:3b3f::1
 php-jump4		IN A 45.112.84.7
 php-jump4		IN AAAA 2a02:cb43:8000::1104
 
-; OS Groups
-windows		IN A 83.137.149.15
-windows		IN AAAA 2a01:1b0:7999:419::7
-windows		IN	TYPE257	\# 22 000569737375656C657473656E63727970742E6F7267
-windows		IN	TYPE257	\# 12 0009697373756577696C643B
-
 ; eUKhost LTD. (contact Philip)
 euk2			IN A 109.203.109.170
 euk3			IN A 109.203.101.62
@@ -202,10 +197,11 @@ wiki.internal         IN CNAME service1-ams.internal.php.net.
 service2-ams.internal IN A 206.189.2.9
 doc.internal          IN CNAME service2-ams.internal.php.net.
 downloads.internal    IN CNAME service2-ams.internal.php.net.
+people.internal       IN CNAME service2-ams.internal.php.net.
 shared.internal       IN CNAME service2-ams.internal.php.net.
 qa.internal           IN CNAME service2-ams.internal.php.net.
 talks.internal        IN CNAME service2-ams.internal.php.net.
-people.internal       IN CNAME service2-ams.internal.php.net.
+windows.internal      IN CNAME service2-ams.internal.php.net.
 www.internal          IN CNAME service2-ams.internal.php.net.
 
 ; Abandoned

--- a/inventory/php/group_vars/service.yml
+++ b/inventory/php/group_vars/service.yml
@@ -55,6 +55,9 @@ doc_domain_alias: doc.internal.php.net
 analytics_domain: analytics.php.net
 analytics_domain_alias: analytics.internal.php.net
 
+windows_domain: windows.php.net
+windows_domain_alias: windows.internal.php.net
+
 www_domain: www.php.net
 www_domain_alias: www.internal.php.net
 

--- a/roles/properties/downloads/templates/downloads.php.net.conf
+++ b/roles/properties/downloads/templates/downloads.php.net.conf
@@ -32,7 +32,9 @@
 
 	# Property Specific Changes
 	RewriteEngine On
-	RewriteRule ^/$ https://php.net/ [L]
+	RewriteRule ^/$          https://www.php.net/downloads.php [L]
+	RewriteRule ^/~windows$  https://www.php.net/downloads.php?os=windows [L]
+	RewriteRule ^/~windows/$ https://www.php.net/downloads.php?os=windows [L]
 
 	# Handle Authorization Header
 	RewriteCond %{HTTP:Authorization} .

--- a/roles/properties/windows/handlers/main.yml
+++ b/roles/properties/windows/handlers/main.yml
@@ -1,0 +1,10 @@
+# This restarts the Apache service
+- name: restart apache
+  service:
+    name: apache2
+    state: restarted
+
+- name: reload apache
+  service:
+    name: apache2
+    state: reloaded

--- a/roles/properties/windows/tasks/deploy.yml
+++ b/roles/properties/windows/tasks/deploy.yml
@@ -1,0 +1,11 @@
+- name: Create local directory to store Windows content
+  file:
+    state: directory
+    dest: "{{ windows_docroot }}/{{ windows_domain }}"
+    mode: "755"
+
+- name: Put robots.txt in document root
+  template:
+    src: templates/robots.txt
+    dest: "{{ windows_docroot }}/{{ windows_domain }}/robots.txt"
+    mode: "644"

--- a/roles/properties/windows/tasks/main.yml
+++ b/roles/properties/windows/tasks/main.yml
@@ -1,0 +1,23 @@
+# This role sets up the property windows.php.net with Apache together with the php module
+# It uses self-signed SSL certs
+
+- name: Add Apache config for windows.php.net
+  template:
+    src: templates/{{ windows_config_file }}
+    dest: "/etc/apache2/sites-available/{{ windows_config_file }}"
+  notify: reload apache
+
+- name: Enable config file
+  shell: "a2ensite {{ windows_config_file }}"
+  args:
+    creates: "/etc/apache2/sites-enabled/{{ windows_config_file }}"
+  notify: reload apache
+
+- name: Ensure Apache is started and enabled
+  service:
+    name: apache2
+    state: started
+    enabled: yes
+
+- include_tasks: deploy.yml
+

--- a/roles/properties/windows/templates/robots.txt
+++ b/roles/properties/windows/templates/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/roles/properties/windows/templates/windows.php.net.conf
+++ b/roles/properties/windows/templates/windows.php.net.conf
@@ -1,0 +1,49 @@
+<VirtualHost *:80>
+	ServerName {{ windows_domain }}
+	ServerAlias {{ windows_domain_alias }}
+
+	ServerAdmin {{ systems_email }}
+	Redirect / https://windows.php.net/
+</VirtualHost>
+
+<IfModule mod_ssl.c>
+<VirtualHost *:443>
+	ServerAdmin {{ systems_email }}
+	ServerName {{ windows_domain }}
+	ServerAlias {{ windows_domain_alias }}
+
+	DocumentRoot {{ windows_docroot }}/{{ windows_domain }}
+
+	RewriteEngine on
+
+	# Redirect content to new location
+	RewriteRule ^/$                       https://www.php.net/downloads.php?os=windows
+	RewriteRule ^/download$               https://www.php.net/downloads.php?os=windows
+	RewriteRule ^/qa$                     https://www.php.net/pre-release-builds.php#windows [NE]
+	RewriteRule ^/qa/$                    https://www.php.net/pre-release-builds.php#windows [NE]
+	RewriteRule ^/snapshots$              https://www.php.net/pre-release-builds.php#windows [NE]
+	RewriteRule ^/snapshots/$             https://www.php.net/pre-release-builds.php#windows [NE]
+	RewriteRule ^/downloads/snaps         https://www.php.net/pre-release-builds.php#windows [NE]
+	RewriteRule ^/downloads/(.*)          https://downloads.php.net/~windows/$1
+
+	# 403 Everything else besides robots.txt
+	RewriteCond %{REQUEST_URI} !^/robots.txt
+	RewriteRule ^/ - [F]
+
+	<Directory {{ windows_docroot }}/{{ windows_domain }}/>
+		Options FollowSymLinks 
+		AllowOverride None
+		Order allow,deny
+		Allow from all
+	</Directory>
+
+	# Logging
+	ErrorLog ${APACHE_LOG_DIR}/{{ windows_domain }}-error.log
+	CustomLog ${APACHE_LOG_DIR}/{{ windows_domain }}-access.log combined
+
+	# TLS Configuration with self-signed certificates
+	SSLEngine on
+	SSLCertificateFile /etc/ssl/certs/php-self-signed.crt
+	SSLCertificateKeyFile /etc/ssl/certs/php-self-signed.key
+</VirtualHost>
+</IfModule>

--- a/roles/properties/windows/vars/main.yml
+++ b/roles/properties/windows/vars/main.yml
@@ -1,0 +1,2 @@
+windows_docroot: /var/www/sites
+windows_config_file: windows.php.net.conf


### PR DESCRIPTION
The idea is that this replaces the current windows.php.net server, with redirects for all original content to the new location on either downloads.php.net or their integrated location on www.php.net

It's possible that I am missing better redirects for common links, so please let me know if I am missing any important ones.

/cc @shivammathur @jrfnl