### PR TITLE
Install exim4 package before configuring

### DIFF
--- a/roles/smtp_smarthost/tasks/main.yml
+++ b/roles/smtp_smarthost/tasks/main.yml
@@ -1,5 +1,10 @@
 # This role sets up the smarthost for emailing emails through the central SMTP server
 
+- name: Install Exim4
+  apt:
+    name: exim4
+    state: present
+
 - name: Add Exim configuration file
   template:
     src: templates/update-exim4.conf.conf


### PR DESCRIPTION
I hit a hard error without this when running `initServiceDynamicSites.yml` when it gets to the `    - role: properties/main` (2nd to last item)