### PR TITLE
Ensure the public_html folder exists before we create a symlink

### DIFF
--- a/roles/properties/pecl/tasks/deploy.yml
+++ b/roles/properties/pecl/tasks/deploy.yml
@@ -1,7 +1,7 @@
 - name: Create local directory to store peclweb content
   file:
     state: directory
-    dest: "{{ pecl_docroot }}/"
+    dest: "{{ pecl_docroot }}/public_html"
     mode: "755"
 
 - name: Create local 'parent' directory to store information


### PR DESCRIPTION
When running `initServiceDynamicSites.yml`, the task `- role: properties/pecl` fails because `public_html` doesn't exist yet. It may exist after running the `initServiceRsync.yml`, but when moving down the list of playbooks, this will error out.

I did not see any impact on the `initServiceRsync.yml` playbook run after this change.