### PR TITLE
Ignore the local inventory directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 local.ansible.cfg
 *.sw?
+inventory/local
+etc/ssh_config_local


### PR DESCRIPTION
This allows users to create their own local instances to test playbooks against. Open to suggestions on naming conventions.