### PR TITLE
Apache and PHP install tasks extracted to be distro aware

### DIFF
--- a/roles/add_apache_with_modules/tasks/debian-12.yml
+++ b/roles/add_apache_with_modules/tasks/debian-12.yml
@@ -1,0 +1,32 @@
+- name: Install Apache with mod-php, php and openssl
+  apt:
+    name:
+      - apache2
+      - libapache2-mod-php8.2
+      - apache2-utils
+      - php8.2
+      - php8.2-bz2
+      - php8.2-intl
+      - php8.2-mbstring
+      - php8.2-xml
+    state: present
+    update_cache: yes
+
+- name: Enable modules in Apache
+  command: a2enmod {{ item }}
+  args:
+    creates: /etc/apache2/mods-enabled/{{ item }}.load
+  loop:
+    - env
+    - ssl
+    - php8.2
+    - headers
+    - rewrite
+    - remoteip
+  notify: reload apache
+
+- name: Add opcache and other local PHP settings
+  template:
+    src: templates/90-local-settings.ini
+    dest: /etc/php/8.2/apache2/conf.d/90-local-settings.ini
+  notify: reload apache

--- a/roles/add_apache_with_modules/tasks/debian-13.yml
+++ b/roles/add_apache_with_modules/tasks/debian-13.yml
@@ -1,0 +1,32 @@
+- name: Install Apache with mod-php, php and openssl
+  apt:
+    name:
+      - apache2
+      - libapache2-mod-php8.4
+      - apache2-utils
+      - php8.4
+      - php8.4-bz2
+      - php8.4-intl
+      - php8.4-mbstring
+      - php8.4-xml
+    state: present
+    update_cache: yes
+
+- name: Enable modules in Apache
+  command: a2enmod {{ item }}
+  args:
+    creates: /etc/apache2/mods-enabled/{{ item }}.load
+  loop:
+    - env
+    - ssl
+    - php8.4
+    - headers
+    - rewrite
+    - remoteip
+  notify: reload apache
+
+- name: Add opcache and other local PHP settings
+  template:
+    src: templates/90-local-settings.ini
+    dest: /etc/php/8.4/apache2/conf.d/90-local-settings.ini
+  notify: reload apache

--- a/roles/add_apache_with_modules/tasks/main.yml
+++ b/roles/add_apache_with_modules/tasks/main.yml
@@ -1,33 +1,18 @@
-- name: Install Apache with mod-php, php and openssl
-  apt:
-    name:
-      - apache2
-      - libapache2-mod-php8.4
-      - apache2-utils
-      - php8.4
-      - php8.4-bz2
-      - php8.4-intl
-      - php8.4-mbstring
-      - php8.4-xml
-    state: present
-    update_cache: yes
+- name: Install Apache and PHP on Debian 12
+  ansible.builtin.include_tasks: debian-12.yml
+  when:
+    - ansible_facts['distribution'] == 'Debian'
+    - ansible_facts['distribution_major_version'] == '12'
+
+- name: Install Apache and PHP on Debian 13
+  ansible.builtin.include_tasks: debian-13.yml
+  when:
+    - ansible_facts['distribution'] == 'Debian'
+    - ansible_facts['distribution_major_version'] == '13'
 
 - name: Create the self-signed SSL Certificate
   include_role:
     name: add_self-signed_certs
-
-- name: Enable modules in Apache
-  command: a2enmod {{ item }}
-  args:
-    creates: /etc/apache2/mods-enabled/{{ item }}.load
-  loop:
-    - env
-    - ssl
-    - php8.4
-    - headers
-    - rewrite
-    - remoteip
-  notify: reload apache
 
 - name: Add remoteip logging config
   template:
@@ -42,12 +27,6 @@
     owner: root
     group: root
     mode: '0644'
-
-- name: Add opcache and other local PHP settings
-  template:
-    src: templates/90-local-settings.ini
-    dest: /etc/php/8.4/apache2/conf.d/90-local-settings.ini
-  notify: reload apache
 
 - name: Create root for all websites
   file:


### PR DESCRIPTION
Resolves #31

Running `ansible-playbook initServiceWiki.yml` which runs against `service5` running Debian 13:

```
...
TASK [Install Apache and common modules] ********************************************************
included: add_apache_with_modules for service5

TASK [add_apache_with_modules : Install Apache and PHP on Debian 12] ****************************
skipping: [service5]

TASK [add_apache_with_modules : Install Apache and PHP on Debian 13] ****************************
included: Code/php/infrastructure/roles/add_apache_with_modules/tasks/debian-13.yml for service5

TASK [add_apache_with_modules : Install Apache with mod-php, php and openssl] *******************
ok: [service5]

TASK [add_apache_with_modules : Enable modules in Apache] ***************************************
ok: [service5] => (item=env)
ok: [service5] => (item=ssl)
ok: [service5] => (item=php8.4)
ok: [service5] => (item=headers)
ok: [service5] => (item=rewrite)
ok: [service5] => (item=remoteip)

TASK [add_apache_with_modules : Add opcache and other local PHP settings] ***********************
ok: [service5]

TASK [Create the self-signed SSL Certificate] ***************************************************
included: add_self-signed_certs for service5

TASK [add_self-signed_certs : Install openssl] **************************************************
ok: [service5]
...
```


Running `ansible-playbook initServiceDynamicSites.yml` which runs against `service3` running Debian 12:

```
...
TASK [Install Apache and common modules] ********************************************************
included: add_apache_with_modules for service3

TASK [add_apache_with_modules : Install Apache and PHP on Debian 12] ****************************
included: Code/php/infrastructure/roles/add_apache_with_modules/tasks/debian-12.yml for service3

TASK [add_apache_with_modules : Install Apache with mod-php, php and openssl] *******************
ok: [service3]

TASK [add_apache_with_modules : Enable modules in Apache] ***************************************
ok: [service3] => (item=env)
ok: [service3] => (item=ssl)
ok: [service3] => (item=php8.2)
ok: [service3] => (item=headers)
ok: [service3] => (item=rewrite)
ok: [service3] => (item=remoteip)

TASK [add_apache_with_modules : Add opcache and other local PHP settings] ***********************
ok: [service3]

TASK [add_apache_with_modules : Install Apache and PHP on Debian 13] ****************************
skipping: [service3]

TASK [Create the self-signed SSL Certificate] ***************************************************
included: add_self-signed_certs for service3

TASK [add_self-signed_certs : Install openssl] **************************************************
ok: [service3]
...
```