### PR TITLE
Loop over nginx log paths for museum

### DIFF
--- a/roles/properties/museum/tasks/main.yml
+++ b/roles/properties/museum/tasks/main.yml
@@ -72,7 +72,7 @@
 
 - name: Set permissions for Nginx logs directory
   file:
-    path: /usr/local/nginx/logs
+    path: "{{ item }}"
     state: directory
     mode: "755"
     owner: www-data


### PR DESCRIPTION
Caught this typo when updating my local infra.

Before:

```
$ ansible-playbook initServiceMuseum.yml

... <snip>

TASK [properties/museum : Include museum config in nginx.conf] *******************************************************
changed: [service8]

TASK [properties/museum : start nginx] *******************************************************************************
[ERROR]: Task failed: Module failed: Unable to start service nginx: Job for nginx.service failed because the control 
process exited with error code.
See "systemctl status nginx.service" and "journalctl -xeu nginx.service" for details.

Origin: /Users/halo/Code/php/infrastructure/roles/properties/museum/tasks/main.yml:126:3

124   notify: reload nginx
125
126 - name: start nginx
      ^ column 3

fatal: [service8]: FAILED! => {"changed": false, "msg": "Unable to start service nginx: Job for nginx.service failed 
because the control process exited with error code.\nSee \"systemctl status nginx.service\" and 
\"journalctl -xeu nginx.service\" for details.\n"}

PLAY RECAP ***********************************************************************************************************
service8                   : ok=24   changed=19   unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```

After on a clean OS:

```
$ ansible-playbook initServiceMuseum.yml

... <snip>

TASK [properties/museum : Set permissions for Nginx temp directory] **************************************************
changed: [service8]

TASK [properties/museum : Set permissions for Nginx logs directory] **************************************************
changed: [service8] => (item=/usr/local/nginx/logs)
changed: [service8] => (item=/var/log/nginx)

... <snip>

PLAY RECAP ***********************************************************************************************************
service8                   : ok=36   changed=26   unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

ansible-playbook initServiceMuseum.yml: 11:27
```