### PR TITLE
Update links to User management in docs and add admin section

### DIFF
--- a/docs/OriginalSetups.md
+++ b/docs/OriginalSetups.md
@@ -93,7 +93,7 @@ It does the following:
   3. Google Auth set up
   4. Set up firewall rules to only log in via jump host IPs
 
-You can add more or delete admins later as well. All user management tasks are outlined in [Users.md](Users.md).
+You can add more or delete admins later as well. All user management tasks are outlined in [ServerAccess.rst](ServerAccess.rst).
 
 
 ## Using Ansible
@@ -177,7 +177,7 @@ Once the machines are initialized, user management tasks are also handled via An
 - Adding a release manager user
 - Deleting a specified user
 
-Details of the user management tasks are outlined in [Users.md](Users.md).
+Details of the user management tasks are outlined in [ServerAccess.rst](ServerAccess.rst).
 
 
 # Additional tasks

--- a/docs/ServerAccess.rst
+++ b/docs/ServerAccess.rst
@@ -89,6 +89,24 @@ list on ``lists.php.net``::
     echo $USER_TO_ADD@php.net >> /var/spool/mlmmj/php-announce/control/moderators
     /usr/bin/mlmmj-sub -L /var/spool/mlmmj/php-announce -a $USER_TO_ADD@php.net
 
+Admins
+------
+
+An admin has access to the jump hosts and all services, and is added to the
+``sudo`` group.
+
+- Store the provided SSH key in ``roles/add_ssh_key/templates/ssh_keys`` using
+  the provided preferred Unix system user name as file name.
+
+- Run::
+
+  ansible-playbook --diff addAdminUser.yml \
+    --extra-vars "username={preferred system user} path_to_google_auth=absolute/path/to/.google_authenticator"
+
+This creates the user on the jump hosts and all services, adds them to the
+``sudo`` group, installs the ``.google_authenticator`` file on the jump host,
+and installs the SSH key everywhere.
+
 Removing a User from All Systems
 ================================
 


### PR DESCRIPTION
Stumbled across a bad link to `Users.md` which was migrated to `Users.rst` and then folded into `ServerAccess.rst`, but was missing the Admin section.

Added the Admin section back and verified the instructions worked as expected. Was able to add and remove an Admin from my local environment.