### PR TITLE
Check if this-box is a symlink to our volume before attempting to create it

### DIFF
--- a/roles/properties/rsync/tasks/main.yml
+++ b/roles/properties/rsync/tasks/main.yml
@@ -8,16 +8,27 @@
     state: present
     update_cache: yes
 
-#- name: Remove box dir if it exists and not a link as the firewall creation
-#        script would have created it
-#  file
+- name: Stat /local/this-box
+  stat:
+    path: "/local/this-box"
+    follow: false
+  register: this_box
+
+- name: Remove /local/this-box if it is not already the correct symlink
+  file:
+    path: "/local/this-box"
+    state: absent
+  when: >
+    not this_box.stat.islnk | default(false)
+    or this_box.stat.lnk_target != rsync_box_volume
 
 - name: Link /local/this-box to {{ rsync_box_volume }}
   file:
     state: link
+    force: yes
+    follow: false
     src: "{{ rsync_box_volume }}"
     dest: "/local/this-box"
-    mode: "755"
     owner: "root"
 
 - name: Create local dirs


### PR DESCRIPTION
## When `/local/this-box` doesn't exist:

```
$ ansible-playbook initServiceRsync.yml
snip
TASK [properties/rsync : Stat /local/this-box] ********************************************
ok: [rsync0]

TASK [properties/rsync : Remove /local/this-box if it is not already the correct symlink] *
skipping: [rsync0]

TASK [properties/rsync : Link /local/this-box to /mnt/volume_ams3_rsync0] *****************
ok: [rsync0]

TASK [properties/rsync : Create local dirs] ***********************************************
ok: [rsync0] => (item=/local/this-box/rsync)
changed: [rsync0] => (item=/local/this-box/rsync/repositories)
changed: [rsync0] => (item=/local/this-box/rsync/repositories/phpdoc-git)
changed: [rsync0] => (item=/local/this-box/rsync/repositories/phpdoc)
changed: [rsync0] => (item=/local/this-box/rsync/mirrors)
snip
```

Symlink Created:

```
root@rsync0-ams:/local# ls -alh
total 12K
drwxr-xr-x  3 root root 4.0K Jun 17 12:02 .
drwxr-xr-x 19 root root 4.0K Jun 11 10:01 ..
drwxr-xr-x  3 root root 4.0K Jun 17 12:02 systems
lrwxrwxrwx  1 root root   23 Jun 17 12:02 this-box -> /mnt/volume_ams3_rsync0
root@rsync0-ams:/local#
```

## When `/local/this-box` Is a symlink to our volume:


```
$ ansible-playbook initServiceRsync.yml
snip
TASK [properties/rsync : Stat /local/this-box] **********************************************
ok: [rsync0]

TASK [properties/rsync : Remove /local/this-box if it is not already the correct symlink] ***
skipping: [rsync0]

TASK [properties/rsync : Link /local/this-box to /mnt/volume_ams3_rsync0] *******************
ok: [rsync0]

TASK [properties/rsync : Create local dirs] *************************************************
changed: [rsync0] => (item=/local/this-box/rsync)
changed: [rsync0] => (item=/local/this-box/rsync/repositories)
changed: [rsync0] => (item=/local/this-box/rsync/repositories/phpdoc-git)
changed: [rsync0] => (item=/local/this-box/rsync/repositories/phpdoc)
changed: [rsync0] => (item=/local/this-box/rsync/mirrors)
snip
```

## When `/local/this-box` is not a symlink:

```
root@rsync0-ams:/local# touch this-box
root@rsync0-ams:/local# ls -alh
total 12K
drwxr-xr-x  3 root root 4.0K Jun 17 12:18 .
drwxr-xr-x 19 root root 4.0K Jun 11 10:01 ..
drwxr-xr-x  3 root root 4.0K Jun 17 12:02 systems
-rw-r--r--  1 root root    0 Jun 17 12:18 this-box
root@rsync0-ams:/local#
```

```
$ ansible-playbook initServiceRsync.yml
snip
TASK [properties/rsync : Stat /local/this-box] ********************************************
ok: [rsync0]

TASK [properties/rsync : Remove /local/this-box if it is not already the correct symlink] *
changed: [rsync0]

TASK [properties/rsync : Link /local/this-box to /mnt/volume_ams3_rsync0] *****************
changed: [rsync0]

TASK [properties/rsync : Create local dirs] ***********************************************
ok: [rsync0] => (item=/local/this-box/rsync)
ok: [rsync0] => (item=/local/this-box/rsync/repositories)
ok: [rsync0] => (item=/local/this-box/rsync/repositories/phpdoc-git)
ok: [rsync0] => (item=/local/this-box/rsync/repositories/phpdoc)
ok: [rsync0] => (item=/local/this-box/rsync/mirrors)
snip
```