### PR TITLE
Add HSTS for php.net based on wiki.php.net

### DIFF
--- a/roles/properties/www/templates/www.php.net.conf
+++ b/roles/properties/www/templates/www.php.net.conf
@@ -23,6 +23,9 @@
 	SSLCertificateFile /etc/ssl/certs/php-self-signed.crt
 	SSLCertificateKeyFile /etc/ssl/certs/php-self-signed.key
 
+    # HSTS (mod_headers is required) (15768000 seconds = 6 months)
+    Header always set Strict-Transport-Security "max-age=15768000"
+
 	# Property Specific Changes
 	AddDefaultCharset utf-8
 	SetEnv MIRROR_LANGUAGE "en"


### PR DESCRIPTION
Addressing https://github.com/php/infrastructure/issues/43 

Adding HSTS for php.net based on [what we have for wiki.php.net](https://github.com/php/infrastructure/blob/21df0e7b449ce8a23d4297f9c6db9a4abe5ce8f2/roles/properties/wiki/templates/wiki.php.net.conf#L18) as a first implementation.

```
$ ansible-playbook initServiceStaticSites.yml

<SNIP>

TASK [add_apache_with_modules : Enable modules in Apache] ********************************
ok: [service7] => (item=env)
ok: [service7] => (item=ssl)
ok: [service7] => (item=php8.4)
ok: [service7] => (item=headers)
ok: [service7] => (item=rewrite)
ok: [service7] => (item=remoteip)
ok: [service7] => (item=status)

TASK [add_apache_with_modules : Add opcache and other local PHP settings] ****************
ok: [service7]

<SNIP>

TASK [properties/www : Add Apache config for www.php.net] ********************************
changed: [service7]

TASK [properties/www : Enable config file] ***********************************************
ok: [service7]

TASK [properties/www : Ensure Apache is started and enabled] *****************************
ok: [service7]

<SNIP>

PLAY RECAP *******************************************************************************
service7: ok=30   changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```