### PR TITLE
If web-php changes then bust Bunny CDN Cache

### DIFF
--- a/inventory/php/group_vars/all.yml.skeleton
+++ b/inventory/php/group_vars/all.yml.skeleton
@@ -35,6 +35,9 @@ github_secret:
 bugs_magic_cookie: 
 flickr_api_token: 
 
+# Bunny CDN account API key, used by update-www to purge the CDN cache
+bunny_api_key:
+
 # OhDearHealthChecks
 ohdear_secret: 
 

--- a/roles/properties/www/tasks/deploy.yml
+++ b/roles/properties/www/tasks/deploy.yml
@@ -9,6 +9,9 @@
     src: templates/update-www
     dest: /local/systems/update-www
     mode: "700"
+  vars:
+    bunny_purge_urls:
+      - "https://www.php.net/pre-release-builds.php*"
 
 - name: Create a cron job to run every 5 minutes
   cron:

--- a/roles/properties/www/templates/update-www
+++ b/roles/properties/www/templates/update-www
@@ -1,7 +1,19 @@
 #!/bin/sh
 
-rsync -rlptDC --timeout=600 --delete --delete-after \
+# export tokens
+export BUNNY_API_KEY="{{ bunny_api_key }}"
+
+CHANGES=$(rsync -rlptDC --timeout=600 --delete --delete-after --itemize-changes \
     --include='distributions/*.exe' --include='manual/en/' \
     --include='manual/en/**' --include='manual/*.php' \
     --include='manual/**' {{ rsync_address }}::phpweb \
-    {{ www_docroot }}
+    {{ www_docroot }})
+
+# Bust the Bunny CDN cache for the pre-release builds page, but only when
+# rsync actually pulled new content (avoids purging on every 5-minute run)
+if [ -n "$CHANGES" ]; then
+    curl --fail --silent --show-error --request POST \
+        --url 'https://api.bunny.net/purge?url=https://www.php.net/pre-release-builds.php*' \
+        --header "AccessKey: ${BUNNY_API_KEY}"
+fi
+

--- a/roles/properties/www/templates/update-www
+++ b/roles/properties/www/templates/update-www
@@ -9,11 +9,14 @@ CHANGES=$(rsync -rlptDC --timeout=600 --delete --delete-after --itemize-changes 
     --include='manual/**' {{ rsync_address }}::phpweb \
     {{ www_docroot }})
 
-# Bust the Bunny CDN cache for the pre-release builds page, but only when
-# rsync actually pulled new content (avoids purging on every 5-minute run)
+# Bust the Bunny CDN cache, but only when rsync actually pulled new
+# content (avoids purging on every 5-minute run). The Bunny purge API
+# takes a single URL per request, so each one is a separate call.
 if [ -n "$CHANGES" ]; then
-    curl --fail --silent --show-error --request POST \
-        --url 'https://api.bunny.net/purge?url=https://www.php.net/pre-release-builds.php*' \
-        --header "AccessKey: ${BUNNY_API_KEY}"
+    for url in {% for url in bunny_purge_urls %}'{{ url }}' {% endfor %}; do
+        curl --fail --silent --show-error --request POST \
+            --url "https://api.bunny.net/purge?url=${url}" \
+            --header "AccessKey: ${BUNNY_API_KEY}"
+    done
 fi
 


### PR DESCRIPTION
Depends on #56 before running this playbook.

Captures the output of the `/local/systems/update-www` script and, if there are changes, we bust the Bunny CDN cache.

Currently, this only affects the specified URL `https://www.php.net/pre-release-builds.php*'` but can be easily extended.

Running locally:

```
$ ansible-playbook initServiceStaticSites.yml

PLAY [static] ***********************************************************************************

TASK [Gather facts for rsync server] ************************************************************
ok: [service7 -> rsync0(192.168.1.52)] => (item=rsync0)

TASK [Install common software and configuration] ************************************************
included: install_common_software for service7

<SNIP>

TASK [properties/www : Create local directory to store www content] *****************************
ok: [service7]

TASK [properties/www : Copy update-www script to the server] ************************************
changed: [service7]

TASK [properties/www : Create a cron job to run every 5 minutes] ********************************
ok: [service7]

<SNIP>

TASK [properties/windows : Put robots.txt in document root] *************************************
ok: [service7]

PLAY RECAP **************************************************************************************
service7 : ok=115  changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

ansible-playbook initServiceStaticSites.yml: 00:44
```

Any URLS we should go ahead and add now?